### PR TITLE
Look up default group

### DIFF
--- a/lib/Daemon/Device.pm
+++ b/lib/Daemon/Device.pm
@@ -40,7 +40,7 @@ sub new {
         my $user = getlogin || getpwuid($<) || 'root';
         $self->{_daemon}{user} ||= $user;
     }
-    $self->{_daemon}{group} ||= $self->{_daemon}{user};
+    $self->{_daemon}{group} ||= (getgrgid((getpwnam($self->{_daemon}{user}))[3]))[0];
 
     croak 'new() called without "daemon" parameter as a hashref' unless ( ref( $self->{_daemon} ) eq 'HASH' );
     for ( qw( program program_args ) ) {


### PR DESCRIPTION
Test fails when installing locally (not as "root") if a group named "$user" does not exist on the system:

Error: Couldn't get gid for non-existent group <$user> at /path/to/Daemon/Control.pm line 175.

Solution: Look up gid for $user, then look up group name for gid.
